### PR TITLE
package.json缺少dotenv依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "axios": "^1.6.7",
+    "dotenv": "^16.0.3",
     "express": "^4.18.3",
     "lodash": "^4.17.20",
     "body-parser": "^1.20.2"


### PR DESCRIPTION
`package.json`不加`dotenv`，部署到 `vercel` 时报 `500` 错误，查看 `logs`发现是缺少依赖导致。
<img width="649" alt="image" src="https://github.com/xiaozhou26/deeplx-pro/assets/40384503/8281335d-0d46-432c-9bad-c237e4b9c167">
