### PR TITLE
fix: 在沉浸式翻譯下，目標語言設定繁體中文會出現錯誤

### DIFF
--- a/translator/translate.go
+++ b/translator/translate.go
@@ -158,6 +158,12 @@ func Translate(text, sourceLang, targetLang, quality string, tryCount int) (stri
 	if targetLang == "EN" {
 		regionalVariant = "en-US"
 	}
+
+	if targetLang == "ZH-HANT" {
+		targetLang = "ZH"
+		regionalVariant = "zh-Hant"
+	}
+
 	if quality == "fast" {
 		priority = -1
 		advancedMode = false


### PR DESCRIPTION
Refs: https://github.com/xiaozhou26/deeplx-pro/issues/14

我發現沉浸式翻譯會把 繁體中文 targetLang 設定成 ZH-HANT，但簡體中文是 ZH

這導致 deepL API會報錯

下面是修正後的代碼，親測可行

```
if targetLang == "ZH-HANT" {
    targetLang = "ZH"
    regionalVariant = "zh-Hant"
}
```